### PR TITLE
Fix secondary aliases not registering

### DIFF
--- a/Core/src/main/java/com/darwinreforged/server/core/commands/CommandBus.java
+++ b/Core/src/main/java/com/darwinreforged/server/core/commands/CommandBus.java
@@ -71,47 +71,8 @@ public abstract class CommandBus<C, A extends ArgumentTypeValue<?>> {
 
             DarwinServer.getLog().info(String.format("\n\nScanning %s for commands", clazz.toGenericString()));
             try {
-                if (clazz.isAnnotationPresent(Command.class)) {
-                    ClassRegistration registration = handleClassType(clazz);
-                    Arrays.stream(registration.getAliases()).forEach(alias -> {
-                        if (!(obj instanceof Class)) registration.setSourceInstance(obj);
-                        AtomicReference<CommandRunner> parentRunner = new AtomicReference<>((s, c) -> s.sendMessage("This command requires arguments!", false));
-                        Arrays.stream(registration.getSubcommands()).forEach(subRegistration -> {
-                            CommandRunner methodRunner = (s, c) -> {
-                                String result = invoke(
-                                        subRegistration.getMethod(),
-                                        s, c,
-                                        subRegistration);
-                                if (result == null || !result.equals("success")) s.sendMessage(DefaultTranslations.UNKNOWN_ERROR.f(result), false);
-                            };
-
-                            if (!subRegistration.getAliases()[0].equals(""))
-                                registerCommand(subRegistration.getCommand().context(), subRegistration.getPermissions()[0].p(), methodRunner);
-                            else {
-                                parentRunner.set(methodRunner);
-                            }
-                        });
-                        registerCommand('*' + registration.getCommand().context(), registration.getPermissions()[0].p(), parentRunner.get());
-                        String[] subcommands = Arrays.stream(registration.getSubcommands()).map(scmd -> scmd.getAliases()[0]).toArray(String[]::new);
-                        DarwinServer.getLog().info(String.format("Registered command : /%s %s", alias, String.join("|", subcommands)));
-                    });
-                } else {
-                    List<Method> methods = new ArrayList<>();
-                    for (Method method : clazz.getDeclaredMethods()) {
-                        method.setAccessible(true);
-                        if (method.isAnnotationPresent(Command.class)) methods.add(method);
-                    }
-                    SingleMethodRegistration[] registrations = handleSingleMethod(methods);
-                    Arrays.stream(registrations)
-                            .forEach(registration -> Arrays.stream(registration.getAliases())
-                                    .forEach(alias -> {
-                                        registerCommand(registration.getCommand().context(), registration.getPermissions()[0].p(), (s, c) -> {
-                                            String result = invoke(registration.getMethod(), s, c, registration);
-                                            if (result == null || !result.equals("success")) s.sendMessage(DefaultTranslations.UNKNOWN_ERROR.f(result), false);
-                                        });
-                                        DarwinServer.getLog().info("Registered singular command : /" + alias);
-                                    }));
-                }
+                if (clazz.isAnnotationPresent(Command.class)) registerClassCommand(clazz, obj);
+                else registerSingleMethodCommand(clazz, obj);
             } catch (Throwable e) {
                 DarwinServer.getLog().warn(String.format("Failed to register potential command class : %s", clazz.toGenericString()));
                 e.printStackTrace();
@@ -119,21 +80,81 @@ public abstract class CommandBus<C, A extends ArgumentTypeValue<?>> {
         }
     }
 
+    private void registerSingleMethodCommand(Class<?> clazz, Object obj) {
+        List<Method> methods = new ArrayList<>();
+        for (Method method : clazz.getDeclaredMethods()) {
+            method.setAccessible(true);
+            if (method.isAnnotationPresent(Command.class)) methods.add(method);
+        }
+        SingleMethodRegistration[] registrations = handleSingleMethod(methods);
+        Arrays.stream(registrations)
+                .forEach(registration -> Arrays.stream(registration.getAliases())
+                        .forEach(alias -> {
+                            String context = registration.getCommand().context();
+                            String primaryAlias = context.substring(context.indexOf(' '));
+                            String next = context.replaceFirst(primaryAlias, alias);
+                            registerCommand(next, registration.getPermission().p(), (s, c) -> {
+                                String result = invoke(registration.getMethod(), s, c, registration);
+                                if (result == null || !result.equals("success")) s.sendMessage(DefaultTranslations.UNKNOWN_ERROR.f(result), false);
+                            });
+                            DarwinServer.getLog().info("Registered singular command : /" + alias);
+                        }));
+    }
+
+    private void registerClassCommand(Class<?> clazz, Object obj) {
+        ClassRegistration registration = handleClassType(clazz);
+        Arrays.stream(registration.getAliases()).forEach(alias -> {
+            if (!(obj instanceof Class)) registration.setSourceInstance(obj);
+            AtomicReference<CommandRunner> parentRunner = new AtomicReference<>((s, c) -> s.sendMessage("This command requires arguments!", false));
+
+            Arrays.stream(registration.getSubcommands()).forEach(subRegistration -> {
+                CommandRunner methodRunner = (s, c) -> {
+                    String result = invoke(
+                            subRegistration.getMethod(),
+                            s, c,
+                            subRegistration);
+                    if (result == null || !result.equals("success")) s.sendMessage(DefaultTranslations.UNKNOWN_ERROR.f(result), false);
+                };
+
+                Arrays.stream(subRegistration.getAliases()).forEach(subAlias -> {
+                    if (!subAlias.equals("")) {
+                        String context = subRegistration.getCommand().context();
+                        String primaryAlias = context.substring(context.indexOf(' '));
+                        String next = context.replaceFirst(primaryAlias, subAlias);
+                        registerCommand(next, subRegistration.getPermission().p(), methodRunner);
+                    } else {
+                        parentRunner.set(methodRunner);
+                    }
+                });
+            });
+
+            String context = registration.getCommand().context();
+            String primaryAlias = context.substring(context.indexOf(' '));
+            String next = context.replaceFirst(primaryAlias, alias);
+            registerCommand('*' + next, registration.getPermission().p(), parentRunner.get());
+
+            // Printing aliases, not used for actual logic
+            List<String> subcommands = new ArrayList<>();
+            Arrays.stream(registration.getSubcommands()).forEach(sub -> subcommands.addAll(Arrays.asList(sub.getAliases())));
+            DarwinServer.getLog().info(String.format("Registered command : /%s %s", alias, String.join("|", subcommands)));
+        });
+    }
+
     private ClassRegistration handleClassType(Class<?> clazz) {
-        Triple<Command, Permissions[], String[]> information = getCommandInformation(clazz);
+        Triple<Command, Permissions, String[]> information = getCommandInformation(clazz);
         Method[] methods = clazz.getDeclaredMethods();
         SingleMethodRegistration[] registrations = handleSingleMethod(Arrays.stream(methods).filter(m -> m.isAnnotationPresent(Command.class)).collect(Collectors.toList()));
         return new ClassRegistration(information.getThird()[0], information.getThird(), information.getSecond(), information.getFirst(), clazz, registrations);
     }
 
-    private Triple<Command, Permissions[], String[]> getCommandInformation(AnnotatedElement element) {
+    private Triple<Command, Permissions, String[]> getCommandInformation(AnnotatedElement element) {
         Command command = element.getAnnotation(Command.class);
-        Permissions[] permissions = new Permissions[]{Permissions.ADMIN_BYPASS};
+        Permissions permission = Permissions.ADMIN_BYPASS;
         if (element.isAnnotationPresent(Permission.class)) {
-            Permission permission = element.getAnnotation(Permission.class);
-            permissions = permission.value();
+            Permission ann = element.getAnnotation(Permission.class);
+            permission = ann.value();
         }
-        return new Triple<>(command, permissions, command.aliases());
+        return new Triple<>(command, permission, command.aliases());
     }
 
     private SingleMethodRegistration[] handleSingleMethod(Collection<Method> methods) {
@@ -171,7 +192,7 @@ public abstract class CommandBus<C, A extends ArgumentTypeValue<?>> {
 
         }).map(method -> {
             method.setAccessible(true);
-            Triple<Command, Permissions[], String[]> information = getCommandInformation(method);
+            Triple<Command, Permissions, String[]> information = getCommandInformation(method);
             return new SingleMethodRegistration(information.getThird()[0], information.getThird(), information.getFirst(), method, information.getSecond());
         }).toArray(SingleMethodRegistration[]::new);
     }

--- a/Core/src/main/java/com/darwinreforged/server/core/commands/CommandBus.java
+++ b/Core/src/main/java/com/darwinreforged/server/core/commands/CommandBus.java
@@ -91,8 +91,7 @@ public abstract class CommandBus<C, A extends ArgumentTypeValue<?>> {
                 .forEach(registration -> Arrays.stream(registration.getAliases())
                         .forEach(alias -> {
                             String context = registration.getCommand().context();
-                            String primaryAlias = context.substring(context.indexOf(' '));
-                            String next = context.replaceFirst(primaryAlias, alias);
+                            String next = context.contains(" ") ? context.replaceFirst(context.substring(0, context.indexOf(' ')), alias) : context;
                             registerCommand(next, registration.getPermission().p(), (s, c) -> {
                                 String result = invoke(registration.getMethod(), s, c, registration);
                                 if (result == null || !result.equals("success")) s.sendMessage(DefaultTranslations.UNKNOWN_ERROR.f(result), false);
@@ -119,8 +118,7 @@ public abstract class CommandBus<C, A extends ArgumentTypeValue<?>> {
                 Arrays.stream(subRegistration.getAliases()).forEach(subAlias -> {
                     if (!subAlias.equals("")) {
                         String context = subRegistration.getCommand().context();
-                        String primaryAlias = context.substring(context.indexOf(' '));
-                        String next = context.replaceFirst(primaryAlias, subAlias);
+                        String next = context.contains(" ") ? context.replaceFirst(context.substring(0, context.indexOf(' ')), alias) : context;
                         registerCommand(next, subRegistration.getPermission().p(), methodRunner);
                     } else {
                         parentRunner.set(methodRunner);
@@ -129,8 +127,7 @@ public abstract class CommandBus<C, A extends ArgumentTypeValue<?>> {
             });
 
             String context = registration.getCommand().context();
-            String primaryAlias = context.substring(context.indexOf(' '));
-            String next = context.replaceFirst(primaryAlias, alias);
+            String next = context.contains(" ") ? context.replaceFirst(context.substring(0, context.indexOf(' ')), alias) : context;
             registerCommand('*' + next, registration.getPermission().p(), parentRunner.get());
 
             // Printing aliases, not used for actual logic

--- a/Core/src/main/java/com/darwinreforged/server/core/commands/annotations/Permission.java
+++ b/Core/src/main/java/com/darwinreforged/server/core/commands/annotations/Permission.java
@@ -14,11 +14,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Permission {
     /**
-     Indicates which permissions should be used for a method or type
+     Indicates which permission should be used for a method or type
      annotated with {@link Command}. Uses the {@link Permissions} type
      to allow for configurable permissions.
 
-     @return the permissions
+     @return the permission
      */
-    Permissions[] value();
+    Permissions value();
 }

--- a/Core/src/main/java/com/darwinreforged/server/core/commands/registrations/ClassRegistration.java
+++ b/Core/src/main/java/com/darwinreforged/server/core/commands/registrations/ClassRegistration.java
@@ -27,7 +27,7 @@ public final class ClassRegistration extends CommandRegistration {
      @param subcommands
      the subcommands
      */
-    public ClassRegistration(String primaryAlias, String[] aliases, Permissions[] permissions, Command command, Class<?> clazz, SingleMethodRegistration[] subcommands) {
+    public ClassRegistration(String primaryAlias, String[] aliases, Permissions permissions, Command command, Class<?> clazz, SingleMethodRegistration[] subcommands) {
         super(primaryAlias, aliases, permissions, command);
         this.clazz = clazz;
         this.subcommands = subcommands;

--- a/Core/src/main/java/com/darwinreforged/server/core/commands/registrations/CommandRegistration.java
+++ b/Core/src/main/java/com/darwinreforged/server/core/commands/registrations/CommandRegistration.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 public abstract class CommandRegistration {
     private final String primaryAlias;
     private final String[] aliases;
-    private final Permissions[] permissions;
+    private final Permissions permission;
     private final Command command;
     private Object sourceInstance;
 
@@ -27,10 +27,10 @@ public abstract class CommandRegistration {
      @param command
      the command
      */
-    public CommandRegistration(String primaryAlias, String[] aliases, Permissions[] permissions, Command command) {
+    public CommandRegistration(String primaryAlias, String[] aliases, Permissions permission, Command command) {
         this.primaryAlias = primaryAlias;
         this.aliases = aliases;
-        this.permissions = permissions;
+        this.permission = permission;
         this.command = command;
     }
 
@@ -65,8 +65,8 @@ public abstract class CommandRegistration {
 
      @return the permissions [ ]
      */
-    public Permissions[] getPermissions() {
-        return permissions;
+    public Permissions getPermission() {
+        return permission;
     }
 
     /**

--- a/Core/src/main/java/com/darwinreforged/server/core/commands/registrations/SingleMethodRegistration.java
+++ b/Core/src/main/java/com/darwinreforged/server/core/commands/registrations/SingleMethodRegistration.java
@@ -23,11 +23,11 @@ public final class SingleMethodRegistration extends CommandRegistration {
      the command
      @param method
      the method
-     @param permissions
+     @param permission
      the permissions
      */
-    public SingleMethodRegistration(String primaryAlias, String[] aliases, Command command, Method method, Permissions[] permissions) {
-        super(primaryAlias, aliases, permissions, command);
+    public SingleMethodRegistration(String primaryAlias, String[] aliases, Command command, Method method, Permissions permission) {
+        super(primaryAlias, aliases, permission, command);
         this.method = method;
     }
 

--- a/Core/src/main/java/com/darwinreforged/server/modules/oldplot/OldPlotModule.java
+++ b/Core/src/main/java/com/darwinreforged/server/modules/oldplot/OldPlotModule.java
@@ -118,7 +118,7 @@ public class OldPlotModule {
                     Vector3i vec3i = new Vector3i(teleportToX, oldPlotWorld.getHeight(), teleportToZ);
                     DarwinLocation location = new DarwinLocation(world, vec3i);
                     player.teleport(location);
-                    player.sendMessage(OldPlotsTranslations.OLP_TELEPORTED_TO.f(teleportToWorld, teleportToX, teleportToZ), false);
+                    player.sendMessage(OldPlotsTranslations.OLP_TELEPORTED_TO.f(teleportToWorld, xArgCandidate.get().getValue(), zArgCandidate.get().getValue()), false);
                 } else {
                     player.sendMessage(OldPlotsTranslations.OLP_NO_WORLD_PRESENT.f(teleportToWorld), false);
                 }


### PR DESCRIPTION
Currently only primary aliases indicated in `context` are being registered. To fix this the context is now updated for each present alias, therefore creating a custom context for each alias. This also affects sub-commands, so e.g. parent command `/tp` and `/teleport` with sub-command `player` and `p` would result in the following contexts : 
- `/tp p`
- `/tp player`
- `/teleport p`
- `/teleport player`